### PR TITLE
Fix test to work on windows

### DIFF
--- a/pkg/pytest/execute_test.go
+++ b/pkg/pytest/execute_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package pytest_test
 
 import (

--- a/pkg/pytest/execute_windows_test.go
+++ b/pkg/pytest/execute_windows_test.go
@@ -1,0 +1,63 @@
+package pytest_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chainer/xpytest/pkg/pytest"
+	xpytest_proto "github.com/chainer/xpytest/proto"
+)
+
+func TestExecute(t *testing.T) {
+	ctx := context.Background()
+	equivalentTrueCmd := []string{"cmd", "/c", "sort < NUL > NUL"}
+	r, err := pytest.Execute(ctx, equivalentTrueCmd, time.Second, nil)
+	if err != nil {
+		t.Fatalf("failed to execute: %s", err)
+	}
+	if r.Status != xpytest_proto.TestResult_SUCCESS {
+		t.Fatalf("unexpected status: %s", r.Status)
+	}
+}
+
+func TestExecuteWithFailure(t *testing.T) {
+	ctx := context.Background()
+	equivalentFalseCmd := []string{"cmd", "/c", "echo Y | choice /C:Y > NUL"}
+	r, err := pytest.Execute(ctx, equivalentFalseCmd, time.Second, nil)
+	if err != nil {
+		t.Fatalf("failed to execute: %s", err)
+	}
+	if r.Status != xpytest_proto.TestResult_FAILED {
+		t.Fatalf("unexpected status: %s", r.Status)
+	}
+}
+
+func TestExecuteWithTimeout(t *testing.T) {
+	ctx := context.Background()
+	r, err := pytest.Execute(
+		ctx, []string{"sleep", "10"}, 100*time.Millisecond, nil)
+	if err != nil {
+		t.Fatalf("failed to execute: %s", err)
+	}
+	if r.Status != xpytest_proto.TestResult_TIMEOUT {
+		t.Fatalf("unexpected status: %s", r.Status)
+	}
+}
+
+func TestExecuteWithEnvironmentVariables(t *testing.T) {
+	ctx := context.Background()
+	r, err := pytest.Execute(
+		ctx, []string{"cmd", "/c", "echo %HOGE%"},
+		time.Second, []string{"HOGE=PIYO"})
+	if err != nil {
+		t.Fatalf("failed to execute: %s", err)
+	}
+	if r.Status != xpytest_proto.TestResult_SUCCESS {
+		t.Fatalf("unexpected status: %s", r.Status)
+	}
+	if r.Stdout != "PIYO\r\n" {
+		t.Fatalf("unexpected output: %s", fmt.Sprintln("PIYO"))
+	}
+}


### PR DESCRIPTION
Current `execute_test.go` fails on windows because the test use shell command.