### PR TITLE
Add CI job on Windows image

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -8,3 +8,18 @@ configs {
     command: "bash .pfnci/script.sh"
   }
 }
+
+configs {
+  key: "xpytest.unit.win"
+  value {
+    requirement {
+      cpu: 2
+      memory: 6
+      image: "windows"
+    }
+    time_limit {
+      seconds: 1800
+    }
+    command: ".pfnci\\script.bat"
+  }
+}

--- a/.pfnci/script.bat
+++ b/.pfnci/script.bat
@@ -1,0 +1,13 @@
+@echo off
+
+set TEST_HOME=%CD%
+cd ..
+curl -o go.zip --insecure -L https://dl.google.com/go/go1.12.4.windows-amd64.zip
+7z x go.zip
+set GOROOT=%CD%\go
+set PATH=%GOROOT%\bin;%PATH%
+set GO111MODULE=on
+
+cd %TEST_HOME%
+go get
+go test -v ./...

--- a/pkg/pytest/execute_windows_test.go
+++ b/pkg/pytest/execute_windows_test.go
@@ -13,7 +13,7 @@ import (
 func TestExecute(t *testing.T) {
 	ctx := context.Background()
 	equivalentTrueCmd := []string{"cmd", "/c", "sort < NUL > NUL"}
-	r, err := pytest.Execute(ctx, equivalentTrueCmd, time.Second, nil)
+	r, err := pytest.Execute(ctx, equivalentTrueCmd, time.Second*3, nil)
 	if err != nil {
 		t.Fatalf("failed to execute: %s", err)
 	}
@@ -25,7 +25,7 @@ func TestExecute(t *testing.T) {
 func TestExecuteWithFailure(t *testing.T) {
 	ctx := context.Background()
 	equivalentFalseCmd := []string{"cmd", "/c", "echo Y | choice /C:Y > NUL"}
-	r, err := pytest.Execute(ctx, equivalentFalseCmd, time.Second, nil)
+	r, err := pytest.Execute(ctx, equivalentFalseCmd, time.Second*3, nil)
 	if err != nil {
 		t.Fatalf("failed to execute: %s", err)
 	}
@@ -37,7 +37,8 @@ func TestExecuteWithFailure(t *testing.T) {
 func TestExecuteWithTimeout(t *testing.T) {
 	ctx := context.Background()
 	r, err := pytest.Execute(
-		ctx, []string{"sleep", "10"}, 100*time.Millisecond, nil)
+		ctx, []string{"cmd", "/c", "ping localhost -n 10 > NUL"},
+		time.Millisecond*100, nil)
 	if err != nil {
 		t.Fatalf("failed to execute: %s", err)
 	}
@@ -50,7 +51,7 @@ func TestExecuteWithEnvironmentVariables(t *testing.T) {
 	ctx := context.Background()
 	r, err := pytest.Execute(
 		ctx, []string{"cmd", "/c", "echo %HOGE%"},
-		time.Second, []string{"HOGE=PIYO"})
+		time.Second*3, []string{"HOGE=PIYO"})
 	if err != nil {
 		t.Fatalf("failed to execute: %s", err)
 	}


### PR DESCRIPTION
- general Windows does not support `sleep` command, to fix this bug (sorry..), replace another command
  - `timeout` command is supported on Windows OS, but could not use on the test because ` Input redirection is not supported, exiting the process immediately.` error
  - so use `ping` command instead
- this timeout test should output `[DEBUG] failed to wait a command: ...: signal: killed
` log, but on Windows, occur `[ERROR] command is hung up: ...` timeout
  - `cmd.Process.Kill()` kills a parent process, so not kills the timeout command directly
  - using `taskkill` command can resolve it, but it looks over the top
- relax timeout range to avoid to be failed by delaying the target command execution
- it's better to get go.exe package from GS like Linux job
- the new job takes over 10min, `go get` on the job takes too long compared with Linux image...