### PR TITLE
Handle tests with no test cases properly

### DIFF
--- a/pkg/pytest/pytest.go
+++ b/pkg/pytest/pytest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -110,16 +109,6 @@ func newPytestResult(p *Pytest, tr *xpytest_proto.TestResult) *Result {
 		} else {
 			result = fmt.Sprintf("%s; %.0f seconds", r.Status, r.duration)
 			r.Status = xpytest_proto.TestResult_INTERNAL
-		}
-		// pytest's message for no tests.
-		if regexp.MustCompile(
-			`^\d+ deselected in \d+(\.\d+)? seconds$`).MatchString(result) {
-			r.Status = xpytest_proto.TestResult_SUCCESS
-		}
-		// pytest-xdist's message for no tests.
-		if regexp.MustCompile(
-			`^no tests ran in \d+(\.\d+)? seconds$`).MatchString(result) {
-			r.Status = xpytest_proto.TestResult_SUCCESS
 		}
 	}
 	r.xdist = p.Xdist

--- a/pkg/pytest/pytest_test.go
+++ b/pkg/pytest/pytest_test.go
@@ -80,26 +80,6 @@ func TestPytestWithXdist(t *testing.T) {
 	}
 }
 
-func TestPytestWhenAllTestsAreDeselected(t *testing.T) {
-	ctx := context.Background()
-	p := pytest.NewPytest("python3")
-	executor := &pytestExecutor{
-		TestResult: &xpytest_proto.TestResult{
-			Status: xpytest_proto.TestResult_FAILED,
-			Stdout: "=== 123 deselected in 1.23 seconds ===",
-		},
-	}
-	p.Executor = executor.Execute
-	p.Files = []string{"test_foo.py"}
-	p.Deadline = time.Minute
-	if r, err := p.Execute(ctx); err != nil {
-		t.Fatalf("failed to execute: %s", err)
-	} else if s := r.Summary(); s !=
-		"[SUCCESS] test_foo.py (123 deselected in 1.23 seconds)" {
-		t.Fatalf("unexpected summary: %s", s)
-	}
-}
-
 func TestPytestWithFlakyTest(t *testing.T) {
 	ctx := context.Background()
 	p := pytest.NewPytest("python3")


### PR DESCRIPTION
https://github.com/chainer/xpytest/pull/5 was merged to resolve an issue on Chainer repository quickly.
Please review both of https://github.com/chainer/xpytest/pull/5 and this PR.

Previously, xpytest dealt with tests with no test cases by parsing test result messages. However, there were some edge cases (e.g., "N deselected, 1 warning" is shown if a warning happens in importing). #5 fixed the issue by checking the status code. pytest documented the exit code (as I wrote in the code), so this fix should be safe.